### PR TITLE
Integrate Jokes API

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
             grid-template-columns: 1fr 3fr 1fr;
             grid-template-rows: 1fr;
             align-items: center;
-            min-height: 100vh;
+            min-height: 90vh;
         }
 
         .container {
@@ -93,13 +93,29 @@
 
         #source {
             margin-top: 15px;
+            margin-bottom: 15px;
+        }
+
+        .joke-sec {
+            border: 1px solid black;
+            text-align: center;
+            padding: 20px;
+            font-size: 1.5rem;
+            margin: auto;
+            background-color: bisque;
+            border: none;
         }
     </style>
 </head>
 <body>
-    
+    <section class="joke-sec">
+        <strong>
+            <em id="joke"></em>
+        </strong>
+    </section>
     <main>
         <section class="container">
+            <h1>Jokesaurus: The Hilarious Dictionary</h1>
             <form onsubmit="return false;">
                 <input type="search" autocomplete="off" autofocus placeholder="Search Word" id="word">
                 <input type="submit" value="Search">

--- a/script.js
+++ b/script.js
@@ -5,9 +5,16 @@ let phoneticsDiv = document.querySelector('#phonetic');
 let meaningsDiv = document.querySelector('#meanings');
 let audioDiv = document.querySelector('#audio');
 let sourceDiv = document.querySelector('#source');
-searchBtn.addEventListener('click', search);
+let joke = document.querySelector('#joke');
+let jokeDiv = document.querySelector('.joke-sec');
 
-function search()
+searchBtn.addEventListener('click', () => {
+    search();
+    getJoke();
+});
+
+
+async function search()
 {
     let word = input.value;
     const xhr = new XMLHttpRequest();
@@ -22,13 +29,13 @@ function search()
         wordDiv.appendChild(msg);
         return;
     }
-    xhr.open('GET', `https://api.dictionaryapi.dev/api/v2/entries/en/${word}`);
+    xhr.open('GET', `https://api.dictionaryapi.dev/api/v2/entries/en/${word}`, true);
 
     xhr.onload = function ()
     {
         if (xhr.status == 200)
         {
-            console.log(JSON.parse(this.responseText));
+            // console.log(JSON.parse(this.responseText));
             let data = JSON.parse(this.responseText)[0];
             let WORD = data['word'];
             let PHONETIC = data['phonetic'];
@@ -130,6 +137,29 @@ function search()
             msg.style.fontSize = 'small';
             msg.innerHTML = 'OOPS! Some error occurred!';
             wordDiv.appendChild(msg);
+        }
+    }
+
+    xhr.send();
+}
+
+async function getJoke()
+{
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://v2.jokeapi.dev/joke/Any?blacklistFlags=nsfw,religious,political,racist,sexist,explicit', true);
+
+    xhr.onload = function()
+    {
+        let jokeInfo = JSON.parse(xhr.responseText);
+        if (jokeInfo['type'] == 'single')
+        {
+            joke.innerHTML = jokeInfo['joke'];
+        }
+        else if (jokeInfo['type'] == 'twopart')
+        {
+            let setup = jokeInfo['setup'].replaceAll('\n', '<br>').trim();
+            let delivery = jokeInfo['delivery'].replaceAll('\n', '<br>').trim();
+            joke.innerHTML = `${setup}<br>${delivery}<br>`;
         }
     }
 


### PR DESCRIPTION
This pull request adds integration with the Jokes API by introducing the getJoke() function. This function retrieves a joke from the Jokes API and displays it on the page.

The getJoke() function uses XMLHttpRequest to send a GET request to the Jokes API endpoint (https://v2.jokeapi.dev/joke/Any?blacklistFlags=nsfw,religious,political,racist,sexist,explicit). Upon receiving a response, the function parses the JSON data and extracts the joke information.

If the joke type is "single," indicating a one-line joke, the function sets the innerHTML of the joke element to the joke text retrieved from the API response.

If the joke type is "twopart," indicating a two-part joke with a setup and delivery, the function retrieves the setup and delivery from the API response, formats them by replacing newline characters with HTML line breaks, and sets the innerHTML of the joke element to the formatted setup and delivery.

These modifications enhance the functionality of the dictionary project by providing users with a joke alongside the dictionary results.